### PR TITLE
Adds useColumnOrder Hook

### DIFF
--- a/src/Components/App/ColumnOrder.js
+++ b/src/Components/App/ColumnOrder.js
@@ -1,0 +1,79 @@
+import React, { useMemo } from "react";
+import { useTable, useColumnOrder } from "react-table";
+import MOCK_DATA from "./../Data/MOCK_DATA.json";
+import { COLUMNS, GROUPED_COLUMNS } from "./Columns";
+
+const ColumnOrder = () => {
+  const columns = useMemo(() => COLUMNS, []);
+  const data = useMemo(() => MOCK_DATA, []);
+
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    footerGroups,
+    rows,
+    prepareRow,
+    setColumnOrder,
+  } = useTable(
+    {
+      columns,
+      data,
+    },
+    useColumnOrder
+  );
+
+  const changeOrder = () => {
+    //array of accessor that we set in Columns.js this is hard coded but you could allow options to sort columns
+    setColumnOrder([
+      "id",
+      "first_name",
+      "last_name",
+      "phone",
+      "country",
+      "date_of_birth",
+    ]);
+  };
+
+  return (
+    <>
+      <button onClick={() => changeOrder()}>Change Column Order</button>
+      <table {...getTableProps()} id="table">
+        <thead>
+          {headerGroups.map((headerGroup) => (
+            <tr {...headerGroup.getHeaderGroupProps()}>
+              {headerGroup.headers.map((column) => (
+                <th {...column.getHeaderProps()}>{column.render("Header")}</th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody {...getTableBodyProps()}>
+          {rows.map((row) => {
+            prepareRow(row);
+            return (
+              <tr {...row.getRowProps()}>
+                {row.cells.map((cell) => {
+                  return (
+                    <td {...cell.getCellProps()}> {cell.render("Cell")}</td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
+        <tfoot>
+          {footerGroups.map((footerGroup) => (
+            <tr {...footerGroup.getFooterGroupProps()}>
+              {footerGroup.headers.map((column) => (
+                <td {...column.getFooterProps}>{column.render("Footer")}</td>
+              ))}
+            </tr>
+          ))}
+        </tfoot>
+      </table>
+    </>
+  );
+};
+
+export default ColumnOrder;

--- a/src/Components/App/Main.js
+++ b/src/Components/App/Main.js
@@ -7,6 +7,7 @@ import GlobalFilter from './GlobalFilter';
 import FilteringTable from "./FilteringTable";
 import PaginationTable from "./PaginationTable";
 import RowSelection from "./RowSelection";
+import ColumnOrder from "./ColumnOrder";
 
 //https://www.balldontlie.io/#getting-started
 // https://www.balldontlie.io/api/v1/players
@@ -24,7 +25,8 @@ const Main = () => {
 
   return (
     <>
-    <RowSelection />
+    <ColumnOrder/>
+    {/* <RowSelection /> */}
     {/* <PaginationTable/> */}
     {/* <FilteringTable /> */}
     {/* <SortingTable/> */}


### PR DESCRIPTION
This hook allows you to destructure the setColumnOrder to set as an array of the accessors in Columns.js to change the column order